### PR TITLE
Fix: add version to readme `uses`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Check if version changed
-      uses: rpiambulance/action-pr-version-check
+      uses: rpiambulance/action-pr-version-check@0.1.1
       with:
         file: package.json # optional, defaults to "package.json"
 ```


### PR DESCRIPTION
Readme code complains on copy paste. This fixes that

![2023-05-16_10-24](https://github.com/rpiambulance/action-pr-version-check/assets/82055622/b996979b-c400-4f5a-80d1-cf8e84c47a54)
